### PR TITLE
Change cd path to cd my-gatsby-site

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -21,7 +21,7 @@ It will look like this, but use your project's directory.
 ```shell
 Start by going to the directory with
 
-cd gatsby-site
+cd my-gatsby-site
 
 Start the local development server with
 


### PR DESCRIPTION
The default site name is now `my-gatsby-site` in the cli flow so I have updated the docs to reflect this change 

```
√ Shall we do this? (Y/n) · Yes
√ Created site from template
PS C:\Users\source\repos\gatsby-app> cd gatsby-site
Set-Location: Cannot find path 'C:\Users\source\repos\gatsby-app\gatsby-site' because it does not exist.

PS C:\Users\source\repos\gatsby-app> cd my-gatsby-site
PS C:\Users\source\repos\gatsby-app\my-gatsby-site> npm run develop
```

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
